### PR TITLE
Add deferred_on filter for exact date matching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Located in `src/omnifocus_mcp/scripts/common/`:
 | File | Purpose |
 |------|---------|
 | `status_maps.js` | Task/project status enums to strings (full and abbreviated) |
-| `filters.js` | Filter factory functions, `isWithinDays()` date helper |
+| `filters.js` | Filter factory functions, `isWithinDays()`, `isOnDay()` date helpers |
 | `field_mappers.js` | Field mapping for tasks/projects/folders, `getFolderPath()` |
 
 ### Patterns to Follow (IMPORTANT)
@@ -185,8 +185,8 @@ with patch("omnifocus_mcp.mcp_tools.response.execute_omnijs_with_params") as moc
   - `summary=True` - Return only counts (projectCount, folderCount, taskCount)
   - `fields` - Select specific fields to reduce response size (includes `folderPath`)
   - `include_folders`/`include_projects`/`include_tasks` - Control what to include
-  - `filters` - Project filters: status, flagged, sequential, tags, due_within, deferred_until, has_note, available
-  - `task_filters` - Task filters (when include_tasks=True): flagged, tags, status, due_within, planned_within
+  - `filters` - Project filters: status, flagged, sequential, tags, due_within, deferred_until, deferred_on, has_note, available
+  - `task_filters` - Task filters (when include_tasks=True): flagged, tags, status, due_within, deferred_on, planned_within
   - Date filters support natural language: "tomorrow", "next week", "in 3 days", etc.
 
 ### Batch Tools
@@ -210,7 +210,7 @@ All user input must pass through `utils.escape_applescript_string()` before bein
 
 ## Natural Language Date Support
 
-Date filters (`due_within`, `deferred_until`, `planned_within`) in `search` and `browse` tools accept natural language:
+Date filters (`due_within`, `deferred_until`, `deferred_on`, `planned_within`) in `search` and `browse` tools accept natural language:
 
 ```python
 # All equivalent ways to search for tasks due within 3 days
@@ -222,6 +222,7 @@ search('tasks', filters={'due_within': '2024-01-28'})  # ISO date
 search('tasks', filters={'due_within': 'tomorrow'})
 search('tasks', filters={'due_within': 'next week'})
 search('tasks', filters={'planned_within': 'this friday'})
+search('tasks', filters={'deferred_on': 'today'})  # Tasks scheduled to start today
 browse(filters={'deferred_until': 'next monday'})
 ```
 

--- a/src/omnifocus_mcp/dates.py
+++ b/src/omnifocus_mcp/dates.py
@@ -43,7 +43,7 @@ def parse_natural_date(value: str) -> datetime | None:
 
 
 # Filters that expect N days from now
-_DAYS_FILTERS = ("due_within", "deferred_until", "planned_within")
+_DAYS_FILTERS = ("due_within", "deferred_until", "planned_within", "deferred_on")
 
 
 def preprocess_date_filters(filters: dict[str, Any]) -> dict[str, Any]:

--- a/src/omnifocus_mcp/mcp_tools/projects/browse.py
+++ b/src/omnifocus_mcp/mcp_tools/projects/browse.py
@@ -47,6 +47,8 @@ async def browse(
                 "next 3 days", "this week", "tomorrow", or numeric days
             - deferred_until: Projects deferred becoming available within N days.
                 Supports natural language like due_within
+            - deferred_on: Projects where defer date equals specific date.
+                Supports natural language like due_within
             - has_note: Filter by note presence (boolean)
             - available: Filter to Active projects that are not deferred (boolean)
         task_filters: Optional filters for tasks when include_tasks=True (all AND logic):
@@ -54,6 +56,7 @@ async def browse(
             - tags: Filter by tag names (list, OR logic)
             - status: Filter by task status (list, OR logic)
             - due_within: Tasks due within N days from today. Supports natural language
+            - deferred_on: Tasks where defer date equals specific date. Supports natural language
             - planned_within: Tasks planned within N days from today. Supports natural language
         include_completed: Include completed/dropped projects and tasks (default: False)
         max_depth: Maximum folder depth to traverse (None = unlimited)

--- a/src/omnifocus_mcp/mcp_tools/query/search.py
+++ b/src/omnifocus_mcp/mcp_tools/query/search.py
@@ -41,6 +41,8 @@ async def search(
                 "next 3 days", "this week", "tomorrow", or numeric days
             - deferred_until: Items deferred becoming available within N days.
                 Supports natural language like due_within
+            - deferred_on: Items where defer date equals specific date. Useful for
+                finding "tasks scheduled to start today". Supports natural language
             - planned_within: Tasks planned within N days from today (OmniFocus 4.7+).
                 Supports natural language like due_within
             - has_note: Filter by note presence

--- a/src/omnifocus_mcp/scripts/common/filters.js
+++ b/src/omnifocus_mcp/scripts/common/filters.js
@@ -27,6 +27,28 @@ function isWithinDays(date, days, requirePastOrPresent) {
 }
 
 /**
+ * Check if a date falls on a specific day (N days from today).
+ * @param {Date|null} date - The date to check
+ * @param {number} daysFromToday - Number of days from today (0=today, 1=tomorrow, -1=yesterday)
+ * @returns {boolean} True if date falls on that specific day
+ */
+function isOnDay(date, daysFromToday) {
+    if (!date) {
+        return false;
+    }
+    var targetDate = new Date();
+    targetDate.setDate(targetDate.getDate() + daysFromToday);
+
+    // Get start of target day (midnight)
+    var startOfDay = new Date(targetDate.getFullYear(), targetDate.getMonth(), targetDate.getDate());
+    // Get end of target day (midnight next day)
+    var endOfDay = new Date(startOfDay);
+    endOfDay.setDate(endOfDay.getDate() + 1);
+
+    return date >= startOfDay && date < endOfDay;
+}
+
+/**
  * Create a filter function for tasks.
  * @param {Object} filters - Filter criteria
  * @param {Object} options - Additional options
@@ -99,6 +121,13 @@ function createTaskFilter(filters, options) {
         // Filter by deferred_until N days
         if (filters.deferred_until !== undefined) {
             if (!isWithinDays(task.deferDate, filters.deferred_until, false)) {
+                return false;
+            }
+        }
+
+        // Filter by deferred_on (exact date match)
+        if (filters.deferred_on !== undefined) {
+            if (!isOnDay(task.deferDate, filters.deferred_on)) {
                 return false;
             }
         }
@@ -199,6 +228,13 @@ function createProjectFilter(filters, options) {
         // Filter by deferred_until N days
         if (filters.deferred_until !== undefined) {
             if (!isWithinDays(project.deferDate, filters.deferred_until, false)) {
+                return false;
+            }
+        }
+
+        // Filter by deferred_on (exact date match)
+        if (filters.deferred_on !== undefined) {
+            if (!isOnDay(project.deferDate, filters.deferred_on)) {
                 return false;
             }
         }

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -244,6 +244,30 @@ class TestBrowse:
             assert params["filters"]["due_within"] == 7
 
     @pytest.mark.asyncio
+    async def test_browse_with_deferred_on_filter(self):
+        """Test project tree with deferred_on filter for exact date match."""
+        with patch("omnifocus_mcp.mcp_tools.response.execute_omnijs_with_params") as mock_exec:
+            mock_exec.return_value = {"tree": [], "projectCount": 0, "folderCount": 0}
+
+            await browse(filters={"deferred_on": "today"})
+
+            script_name, params, *_ = mock_exec.call_args[0]
+            # "today" should be converted to 0 days from today
+            assert params["filters"]["deferred_on"] == 0
+
+    @pytest.mark.asyncio
+    async def test_browse_with_task_deferred_on_filter(self):
+        """Test browse with deferred_on filter in task_filters."""
+        with patch("omnifocus_mcp.mcp_tools.response.execute_omnijs_with_params") as mock_exec:
+            mock_exec.return_value = {"tree": [], "projectCount": 0, "folderCount": 0}
+
+            await browse(include_tasks=True, task_filters={"deferred_on": "tomorrow"})
+
+            script_name, params, *_ = mock_exec.call_args[0]
+            # "tomorrow" should be converted to 1 day
+            assert params["task_filters"]["deferred_on"] == 1
+
+    @pytest.mark.asyncio
     async def test_browse_exclude_root_projects(self):
         """Test project tree with include_root_projects=False."""
         with patch("omnifocus_mcp.mcp_tools.response.execute_omnijs_with_params") as mock_exec:

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -133,11 +133,28 @@ class TestPreprocessDateFilters:
             "due_within": "tomorrow",
             "deferred_until": "in 2 days",
             "planned_within": "in 5 days",
+            "deferred_on": "today",
         }
         result = preprocess_date_filters(filters)
         assert result["due_within"] == 1
         assert result["deferred_until"] == 2
         assert result["planned_within"] == 5
+        assert result["deferred_on"] == 0
+
+    def test_deferred_on_filter_today(self):
+        """Test deferred_on 'today' converts to 0 days."""
+        result = preprocess_date_filters({"deferred_on": "today"})
+        assert result["deferred_on"] == 0
+
+    def test_deferred_on_filter_tomorrow(self):
+        """Test deferred_on 'tomorrow' converts to 1 day."""
+        result = preprocess_date_filters({"deferred_on": "tomorrow"})
+        assert result["deferred_on"] == 1
+
+    def test_deferred_on_filter_yesterday(self):
+        """Test deferred_on 'yesterday' converts to -1 day."""
+        result = preprocess_date_filters({"deferred_on": "yesterday"})
+        assert result["deferred_on"] == -1
 
     def test_unparseable_filter_removed(self):
         """Test that unparseable string filters are removed."""

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -160,6 +160,29 @@ class TestSearch:
             assert params["filters"]["deferred_until"] == 3
 
     @pytest.mark.asyncio
+    async def test_search_with_deferred_on_filter(self):
+        """Test search with deferred_on filter for exact date match."""
+        with patch("omnifocus_mcp.mcp_tools.response.execute_omnijs_with_params") as mock_exec:
+            mock_exec.return_value = {"count": 0, "entity": "tasks", "items": []}
+
+            await search(entity="tasks", filters={"deferred_on": 0})  # Today
+
+            script_name, params, *_ = mock_exec.call_args[0]
+            assert params["filters"]["deferred_on"] == 0
+
+    @pytest.mark.asyncio
+    async def test_search_with_deferred_on_natural_language(self):
+        """Test search with deferred_on filter using natural language."""
+        with patch("omnifocus_mcp.mcp_tools.response.execute_omnijs_with_params") as mock_exec:
+            mock_exec.return_value = {"count": 0, "entity": "tasks", "items": []}
+
+            await search(entity="tasks", filters={"deferred_on": "tomorrow"})
+
+            script_name, params, *_ = mock_exec.call_args[0]
+            # "tomorrow" should be converted to 1 day from today
+            assert params["filters"]["deferred_on"] == 1
+
+    @pytest.mark.asyncio
     async def test_search_with_planned_within_filter(self):
         """Test search with planned_within filter."""
         with patch("omnifocus_mcp.mcp_tools.response.execute_omnijs_with_params") as mock_exec:


### PR DESCRIPTION
## Summary

Closes #4

- Add `deferred_on` filter to find tasks/projects where the defer date equals a specific date
- Enables morning planning ("tasks that became available today") and evening prep ("tasks scheduled to start tomorrow") use cases
- Supports natural language dates via the existing date preprocessing from #3

## Changes

- Add `isOnDay()` helper function in `filters.js` for exact date matching
- Add `deferred_on` filter to both `createTaskFilter` and `createProjectFilter`
- Add `deferred_on` to date preprocessing in `dates.py`
- Update docstrings in `search.py` and `browse.py`
- Add 7 new tests covering the filter functionality
- Update `CLAUDE.md` documentation

## Example Usage

```python
# Tasks deferred to today (morning planning)
search(entity="tasks", filters={"deferred_on": "today"})

# Tasks deferred to tomorrow (evening prep)
search(entity="tasks", filters={"deferred_on": "tomorrow"})

# Tasks deferred to next Monday
search(entity="tasks", filters={"deferred_on": "next monday"})
```

## Test plan

- [x] All 181 tests pass
- [x] New tests cover `deferred_on` in search, browse, and date preprocessing
- [x] Natural language parsing works (today, tomorrow, next monday, ISO dates)